### PR TITLE
[DAT-1439] Add authenticated user to handleAuthorizedRequest

### DIFF
--- a/api/src/test/java/de/cyface/api/AuthorizationTest.java
+++ b/api/src/test/java/de/cyface/api/AuthorizationTest.java
@@ -288,7 +288,7 @@ public class AuthorizationTest {
         }
 
         @Override
-        protected void handleAuthorizedRequest(final RoutingContext ctx, final Set<User> users,
+        protected void handleAuthorizedRequest(final RoutingContext ctx, final User user, final Set<User> users,
                 final MultiMap header) {
             // Nothing to do
         }

--- a/api/src/test/java/de/cyface/api/AuthorizerTest.java
+++ b/api/src/test/java/de/cyface/api/AuthorizerTest.java
@@ -172,7 +172,7 @@ public class AuthorizerTest {
         }
 
         @Override
-        protected void handleAuthorizedRequest(RoutingContext ctx, Set<User> users, MultiMap header) {
+        protected void handleAuthorizedRequest(RoutingContext ctx, User user, Set<User> users, MultiMap header) {
             // Nothing to do
         }
     }


### PR DESCRIPTION
To reduce code duplication (see discussion [here](https://github.com/cyface-de/data-provider/pull/18#discussion_r958531323)) this PR adds the currently authenticated user to `handleAuthorizedRequest`.