### PR TITLE
Task/rfr 510 support oauth

### DIFF
--- a/api-test-environment/build.gradle
+++ b/api-test-environment/build.gradle
@@ -21,7 +21,6 @@ dependencies {
   // Test Dependencies
   implementation "org.junit.jupiter:junit-jupiter:$junitVersion"
   implementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
-  implementation "org.hamcrest:hamcrest:$hamcrestVersion"
   implementation "org.mockito:mockito-core:$mockitoVersion"
   implementation "io.vertx:vertx-junit5:$vertxVersion"
   implementation "io.vertx:vertx-web-client:$vertxVersion"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -38,5 +38,4 @@ dependencies {
   testImplementation project(':api-test-environment')
   testImplementation "io.vertx:vertx-junit5:$vertxVersion"
   testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
-  implementation "org.hamcrest:hamcrest:$hamcrestVersion"
 }

--- a/api/src/main/java/de/cyface/api/PauseAndResumeStrategy.java
+++ b/api/src/main/java/de/cyface/api/PauseAndResumeStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Cyface GmbH
+ * Copyright 2022-2023 Cyface GmbH
  *
  * This file is part of the Cyface API Library.
  *
@@ -19,17 +19,16 @@
 package de.cyface.api;
 
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.ext.web.RoutingContext;
 
 /**
- * The interface for pause and resume strategies to be used which wraps async calls in
- * {@link Authorizer#handle(RoutingContext)}.
+ * The interface for pause and resume strategies to be used which wraps async calls, e.g. in
+ * {@code Authorizer#handle(RoutingContext)}.
  * <p>
  * Use {@link PauseAndResumeBeforeBodyParsing} when the `BodyHandler` is not executed before that handler [DAT-749] or
  * {@link PauseAndResumeAfterBodyParsing} otherwise.
  *
  * @author Armin Schnabel
- * @version 1.0.1
+ * @version 1.0.2
  * @since 1.0.0
  */
 public interface PauseAndResumeStrategy {

--- a/api/src/main/java/de/cyface/api/PauseAndResumeStrategy.java
+++ b/api/src/main/java/de/cyface/api/PauseAndResumeStrategy.java
@@ -22,7 +22,7 @@ import io.vertx.core.http.HttpServerRequest;
 
 /**
  * The interface for pause and resume strategies to be used which wraps async calls, e.g. in
- * {@code Authorizer#handle(RoutingContext)}.
+ * {@code AuthorizationHandler}s in APIs which use this library (e.g. collector, incentives).
  * <p>
  * Use {@link PauseAndResumeBeforeBodyParsing} when the `BodyHandler` is not executed before that handler [DAT-749] or
  * {@link PauseAndResumeAfterBodyParsing} otherwise.

--- a/api/src/main/java/de/cyface/api/model/User.java
+++ b/api/src/main/java/de/cyface/api/model/User.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022-2023 Cyface GmbH
+ *
+ * This file is part of the Cyface API Library.
+ *
+ * The Cyface API Library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Cyface API Library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the Cyface API Library. If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.cyface.api.model;
+
+import static io.vertx.ext.auth.mongo.MongoAuthorization.DEFAULT_USERNAME_FIELD;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * This class represents a user.
+ *
+ * @author Armin Schnabel
+ * @version 2.0.0
+ * @since 1.0.0
+ */
+public class User {
+
+    /**
+     * The identifier of the {@link User}.
+     */
+    private final UUID id;
+    /**
+     * The username of the {link User}.
+     */
+    private final String name;
+
+    /**
+     * Constructs a fully initialized instance of this class.
+     *
+     * @param id The identifier of the {@link User}.
+     * @param name The username of the {link User}.
+     */
+    public User(final UUID id, final String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    /**
+     * Constructs a fully initialized instance of this class.
+     *
+     * @param databaseValue A role entry from the database.
+     */
+    public User(final JsonObject databaseValue) {
+        this.id = UUID.fromString(databaseValue.getString("_id"));
+        this.name = databaseValue.getString(DEFAULT_USERNAME_FIELD);
+    }
+
+    /**
+     * @return The identifier of the {@link User}.
+     */
+    @SuppressWarnings("unused") // Part of the API
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+     * @return The identifier of the {@link User} as {@code String}.
+     */
+    @SuppressWarnings("unused") // Part of the API
+    public String getIdString() {
+        return id.toString();
+    }
+
+    /**
+     * @return The username of the {link User}.
+     */
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        User user = (User)o;
+        return id.equals(user.id) && name.equals(user.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/api/src/main/java/de/cyface/api/model/User.java
+++ b/api/src/main/java/de/cyface/api/model/User.java
@@ -32,6 +32,7 @@ import io.vertx.core.json.JsonObject;
  * @version 2.0.0
  * @since 1.0.0
  */
+@SuppressWarnings("unused") // Part of the API (e.g. used by collector, incentives)
 public class User {
 
     /**

--- a/api/src/main/java/de/cyface/api/v2/Authorizer.java
+++ b/api/src/main/java/de/cyface/api/v2/Authorizer.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface API Library. If not, see <http://www.gnu.org/licenses/>.
  */
-package de.cyface.api;
+package de.cyface.api.v2;
 
 import static io.vertx.ext.auth.mongo.MongoAuthorization.DEFAULT_ROLE_FIELD;
 import static io.vertx.ext.auth.mongo.MongoAuthorization.DEFAULT_USERNAME_FIELD;
@@ -27,12 +27,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import de.cyface.api.DatabaseConstants;
+import de.cyface.api.PauseAndResumeStrategy;
+import de.cyface.api.v2.model.Role;
+import de.cyface.api.v2.model.User;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.cyface.api.model.Role;
-import de.cyface.api.model.User;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -161,7 +163,7 @@ public abstract class Authorizer implements Handler<RoutingContext> {
      * @param header the header of the request which may contain parameters required to process the request.
      */
     protected abstract void handleAuthorizedRequest(final RoutingContext ctx, final User user, final Set<User> users,
-            final MultiMap header);
+                                                    final MultiMap header);
 
     /**
      * Loads all users which the authenticated {@code User} can access.

--- a/api/src/main/java/de/cyface/api/v2/Authorizer.java
+++ b/api/src/main/java/de/cyface/api/v2/Authorizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Cyface GmbH
+ * Copyright 2019-2023 Cyface GmbH
  *
  * This file is part of the Cyface API Library.
  *
@@ -50,7 +50,7 @@ import io.vertx.ext.web.RoutingContext;
  * This class ensures that such requests are properly authorized.
  *
  * @author Armin Schnabel
- * @version 2.0.2
+ * @version 2.0.3
  * @since 1.0.0
  */
 public abstract class Authorizer implements Handler<RoutingContext> {

--- a/api/src/main/java/de/cyface/api/v2/UserRetriever.java
+++ b/api/src/main/java/de/cyface/api/v2/UserRetriever.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Cyface GmbH - All Rights Reserved
+ * Copyright (C) 2022-2023 Cyface GmbH - All Rights Reserved
  *
  * This file is part of the Cyface API Library.
  *
@@ -32,7 +32,7 @@ import io.vertx.ext.mongo.MongoClient;
  * Loads {@link User}s from the database for a vert.x context.
  *
  * @author Armin Schnabel
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public class UserRetriever {

--- a/api/src/main/java/de/cyface/api/v2/UserRetriever.java
+++ b/api/src/main/java/de/cyface/api/v2/UserRetriever.java
@@ -16,12 +16,12 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface API Library. If not, see <http://www.gnu.org/licenses/>.
  */
-package de.cyface.api;
+package de.cyface.api.v2;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import de.cyface.api.model.User;
+import de.cyface.api.v2.model.User;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;

--- a/api/src/main/java/de/cyface/api/v2/model/Role.java
+++ b/api/src/main/java/de/cyface/api/v2/model/Role.java
@@ -28,7 +28,7 @@ import de.cyface.api.DatabaseConstants;
  * This class represents a user role of a specific {@link Type}.
  *
  * @author Armin Schnabel
- * @version 1.2.0
+ * @version 1.2.1
  * @since 1.0.0
  */
 public class Role {

--- a/api/src/main/java/de/cyface/api/v2/model/Role.java
+++ b/api/src/main/java/de/cyface/api/v2/model/Role.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface API Library. If not, see <http://www.gnu.org/licenses/>.
  */
-package de.cyface.api.model;
+package de.cyface.api.v2.model;
 
 import java.util.Objects;
 

--- a/api/src/main/java/de/cyface/api/v2/model/User.java
+++ b/api/src/main/java/de/cyface/api/v2/model/User.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface API Library. If not, see <http://www.gnu.org/licenses/>.
  */
-package de.cyface.api.model;
+package de.cyface.api.v2.model;
 
 import io.vertx.core.json.JsonObject;
 import org.bson.types.ObjectId;

--- a/api/src/test/java/de/cyface/api/AuthenticatorTest.java
+++ b/api/src/test/java/de/cyface/api/AuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Cyface GmbH
+ * Copyright 2022-2023 Cyface GmbH
  *
  * This file is part of the Cyface API Library.
  *
@@ -18,10 +18,15 @@
  */
 package de.cyface.api;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerResponse;
@@ -30,14 +35,13 @@ import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.mongo.MongoAuthentication;
 import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
-import org.junit.jupiter.api.Test;
 
 /**
  * This class checks the inner workings of the {@link Authenticator}.
  *
  * @author Armin Schnabel
  * @author Klemens Muthmann
- * @version 1.1.0
+ * @version 1.1.1
  * @since 1.0.0
  */
 @SuppressWarnings({"SpellCheckingInspection"})
@@ -59,9 +63,9 @@ public class AuthenticatorTest {
         final var createdResult = Authenticator.activated(createdPrincipal);
 
         // Assert
-        assertThat("Check activation", registeredResult, is(equalTo(false)));
-        assertThat("Check activation", activatedResult, is(equalTo(true)));
-        assertThat("Check activation", createdResult, is(equalTo(true)));
+        assertFalse(registeredResult, "Check activation");
+        assertTrue(activatedResult, "Check activation");
+        assertTrue(createdResult, "Check activation");
     }
 
     /**
@@ -87,7 +91,8 @@ public class AuthenticatorTest {
         when(mockBody.asJsonObject()).thenReturn(testCredentials);
         when(mockAuthentication.authenticate(any(JsonObject.class))).thenReturn(mockAuthenticationResult);
 
-        final var oocut = new Authenticator(mockAuthentication, mockAuthProvider, issuer, audience, tokenValidationTime);
+        final var oocut = new Authenticator(mockAuthentication, mockAuthProvider, issuer, audience,
+                tokenValidationTime);
 
         // Act
         oocut.handle(mockContext);

--- a/api/src/test/java/de/cyface/api/HasherTest.java
+++ b/api/src/test/java/de/cyface/api/HasherTest.java
@@ -18,9 +18,7 @@
  */
 package de.cyface.api;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.charset.StandardCharsets;
 
@@ -51,7 +49,7 @@ public class HasherTest {
         final var result = oocut.hash(password);
 
         // Assert
-        assertThat("Compare generated hashcode", result, is(equalTo(
-                "$pbkdf2$U1VHQVI=$ZK4ZDOf9i3AibLO23RwmTmwfSe4qCQl0Mxl1zSPPW1+tF593v3Ip5RjiWU8j6M251AYjic8V/lhLsxukCpi/Ig")));
+        final var expected = "$pbkdf2$U1VHQVI=$ZK4ZDOf9i3AibLO23RwmTmwfSe4qCQl0Mxl1zSPPW1+tF593v3Ip5RjiWU8j6M251AYjic8V/lhLsxukCpi/Ig";
+        assertEquals(expected, result, "Compare generated hashcode");
     }
 }

--- a/api/src/test/java/de/cyface/api/v2/AuthorizationTest.java
+++ b/api/src/test/java/de/cyface/api/v2/AuthorizationTest.java
@@ -18,9 +18,8 @@
  */
 package de.cyface.api.v2;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,12 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import de.cyface.api.AuthenticatedEndpointConfig;
-import de.cyface.api.DatabaseConstants;
-import de.cyface.api.EndpointConfig;
-import de.cyface.api.PauseAndResumeAfterBodyParsing;
 import org.apache.commons.lang3.Validate;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,6 +38,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import de.cyface.api.AuthenticatedEndpointConfig;
+import de.cyface.api.DatabaseConstants;
+import de.cyface.api.EndpointConfig;
+import de.cyface.api.PauseAndResumeAfterBodyParsing;
 import de.cyface.api.v2.model.Role;
 import de.cyface.api.v2.model.User;
 import de.cyface.apitestutils.TestMongoDatabase;
@@ -143,9 +141,9 @@ public class AuthorizationTest {
 
                         // Assert
                         final var expectedUsernames = env.getExpectedUsernames();
-                        assertThat(users, hasSize(expectedUsernames.size()));
-                        MatcherAssert.assertThat(users.stream().map(User::getName).collect(Collectors.toList()),
-                                hasItems(expectedUsernames.toArray(new String[0])));
+                        assertEquals(expectedUsernames.size(), users.size());
+                        assertArrayEquals(expectedUsernames.toArray(new String[0]),
+                                users.stream().map(User::getName).toArray());
                         testContext.completeNow();
                     }));
                     loadUsers.onFailure(testContext::failNow);
@@ -184,9 +182,9 @@ public class AuthorizationTest {
                         // Assert
                         final var expectedUsernames = List
                                 .of(new String[] {groupUser.getUsername(), groupManager.getUsername()});
-                        assertThat(users, hasSize(expectedUsernames.size()));
-                        MatcherAssert.assertThat(users.stream().map(User::getName).collect(Collectors.toList()),
-                                hasItems(expectedUsernames.toArray(new String[0])));
+                        assertEquals(expectedUsernames.size(), users.size());
+                        assertArrayEquals(expectedUsernames.toArray(new String[0]),
+                                users.stream().map(User::getName).toArray());
                         testContext.completeNow();
                     }));
                     loadUsers.onFailure(testContext::failNow);

--- a/api/src/test/java/de/cyface/api/v2/AuthorizationTest.java
+++ b/api/src/test/java/de/cyface/api/v2/AuthorizationTest.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface API Library. If not, see <http://www.gnu.org/licenses/>.
  */
-package de.cyface.api;
+package de.cyface.api.v2;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
@@ -30,7 +30,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import de.cyface.api.AuthenticatedEndpointConfig;
+import de.cyface.api.DatabaseConstants;
+import de.cyface.api.EndpointConfig;
+import de.cyface.api.PauseAndResumeAfterBodyParsing;
 import org.apache.commons.lang3.Validate;
+import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,8 +44,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import de.cyface.api.model.Role;
-import de.cyface.api.model.User;
+import de.cyface.api.v2.model.Role;
+import de.cyface.api.v2.model.User;
 import de.cyface.apitestutils.TestMongoDatabase;
 import de.cyface.apitestutils.fixture.user.DirectTestUser;
 import de.cyface.apitestutils.fixture.user.TestUser;
@@ -139,7 +144,7 @@ public class AuthorizationTest {
                         // Assert
                         final var expectedUsernames = env.getExpectedUsernames();
                         assertThat(users, hasSize(expectedUsernames.size()));
-                        assertThat(users.stream().map(User::getName).collect(Collectors.toList()),
+                        MatcherAssert.assertThat(users.stream().map(User::getName).collect(Collectors.toList()),
                                 hasItems(expectedUsernames.toArray(new String[0])));
                         testContext.completeNow();
                     }));
@@ -180,7 +185,7 @@ public class AuthorizationTest {
                         final var expectedUsernames = List
                                 .of(new String[] {groupUser.getUsername(), groupManager.getUsername()});
                         assertThat(users, hasSize(expectedUsernames.size()));
-                        assertThat(users.stream().map(User::getName).collect(Collectors.toList()),
+                        MatcherAssert.assertThat(users.stream().map(User::getName).collect(Collectors.toList()),
                                 hasItems(expectedUsernames.toArray(new String[0])));
                         testContext.completeNow();
                     }));

--- a/api/src/test/java/de/cyface/api/v2/AuthorizerTest.java
+++ b/api/src/test/java/de/cyface/api/v2/AuthorizerTest.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface API Library. If not, see <http://www.gnu.org/licenses/>.
  */
-package de.cyface.api;
+package de.cyface.api.v2;
 
 import static io.vertx.ext.auth.mongo.MongoAuthorization.DEFAULT_ROLE_FIELD;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import de.cyface.api.DatabaseConstants;
+import de.cyface.api.PauseAndResumeAfterBodyParsing;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,8 +42,8 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import de.cyface.api.model.Role;
-import de.cyface.api.model.User;
+import de.cyface.api.v2.model.Role;
+import de.cyface.api.v2.model.User;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;

--- a/api/src/test/java/de/cyface/api/v2/AuthorizerTest.java
+++ b/api/src/test/java/de/cyface/api/v2/AuthorizerTest.java
@@ -19,9 +19,7 @@
 package de.cyface.api.v2;
 
 import static io.vertx.ext.auth.mongo.MongoAuthorization.DEFAULT_ROLE_FIELD;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,8 +29,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import de.cyface.api.DatabaseConstants;
-import de.cyface.api.PauseAndResumeAfterBodyParsing;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +38,8 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import de.cyface.api.DatabaseConstants;
+import de.cyface.api.PauseAndResumeAfterBodyParsing;
 import de.cyface.api.v2.model.Role;
 import de.cyface.api.v2.model.User;
 import io.vertx.core.Future;
@@ -92,7 +90,7 @@ public class AuthorizerTest {
         final var result = oocut.loadAccessibleUsers(principal).result();
 
         // Assert
-        assertThat(result, is(equalTo(parameters.expectedResult)));
+        assertEquals(parameters.expectedResult, result);
     }
 
     @ParameterizedTest

--- a/api/src/test/java/de/cyface/api/v2/RoleTest.java
+++ b/api/src/test/java/de/cyface/api/v2/RoleTest.java
@@ -18,9 +18,7 @@
  */
 package de.cyface.api.v2;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
 
@@ -50,7 +48,7 @@ public class RoleTest {
         final var oocut = new Role(parameters.databaseValue);
 
         // Assert
-        assertThat(oocut, is(equalTo(parameters.role)));
+        assertEquals(parameters.role, oocut);
     }
 
     @Test
@@ -72,7 +70,7 @@ public class RoleTest {
         final var oocut = parameters.role;
 
         // Assert
-        assertThat(oocut.databaseIdentifier(), is(equalTo(parameters.databaseValue)));
+        assertEquals(parameters.databaseValue, oocut.databaseIdentifier());
     }
 
     @Test

--- a/api/src/test/java/de/cyface/api/v2/RoleTest.java
+++ b/api/src/test/java/de/cyface/api/v2/RoleTest.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface API Library. If not, see <http://www.gnu.org/licenses/>.
  */
-package de.cyface.api;
+package de.cyface.api.v2;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import de.cyface.api.model.Role;
+import de.cyface.api.v2.model.Role;
 
 /**
  * Tests whether the roles constructions from database values works as expected.

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,6 @@ subprojects {
     // Versions of testing dependencies
     junitVersion = '5.9.2'
     mockitoVersion = '5.2.0'
-    hamcrestVersion = '2.2'
     flapdoodleVersion = '3.5.3' // major upgrade available
 
     jacocoVersion = '0.8.9'
@@ -110,7 +109,6 @@ subprojects {
     // Testing Dependencies
     testImplementation(platform("org.junit:junit-bom:$junitVersion"))
     testImplementation "org.junit.jupiter:junit-jupiter-params"  // Required for parameterized tests
-    testImplementation "org.hamcrest:hamcrest:$hamcrestVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"


### PR DESCRIPTION
As the user is now stored in Keycloak, the user.id of our `User` model is now UUID instead of ObjectId.

This PR changes this and moves the classes required by APIs which did not move to OAuth yet (data-provider) to a separate package.